### PR TITLE
AzureSearchRequestBuilder: fixed request duplication

### DIFF
--- a/VirtoCommerce.AzureSearchModule.Data/AzureSearchRequestBuilder.cs
+++ b/VirtoCommerce.AzureSearchModule.Data/AzureSearchRequestBuilder.cs
@@ -53,7 +53,7 @@ namespace VirtoCommerce.AzureSearchModule.Data
             {
                 primaryRequest = CreateRawQueryRequest(request, sorting, request.Skip, request.Take);
             }
-            result.Insert(0, primaryRequest); result.Insert(0, primaryRequest);
+            result.Insert(0, primaryRequest);
             return result;
         }
 


### PR DESCRIPTION
Azure search module was sending all search requests twice. Contents of both requests were identical, and they were executing simultaneously.
I've found a [line in `AzureSearchRequestBuilder`](https://github.com/VirtoCommerce/vc-module-azure-search/commit/3db1bf2b5849fbd02103aad17f501186bb974897#diff-84f46d10343544ae938c8fcdc78f9effR56) which causes the duplication. Apparently, it was added when merging PR #3. The PR itself does not contain the duplication, and after discussing it with @Andrew-Orlov we considered that this is probably just a typo.