### PR TITLE
VP-7292 Change Dictionary to Concurrent Dictionary

### DIFF
--- a/src/VirtoCommerce.AzureSearchModule.Data/AzureSearchProvider.cs
+++ b/src/VirtoCommerce.AzureSearchModule.Data/AzureSearchProvider.cs
@@ -315,6 +315,12 @@ namespace VirtoCommerce.AzureSearchModule.Data
             return Client.Indexes.ExistsAsync(indexName);
         }
 
+        protected virtual async Task<IList<Field>> GetIndexFields(string indexName)
+        {
+            var index = await Client.Indexes.GetAsync(indexName);
+            return index.Fields;
+        }
+
         #region Create and configure index
 
         protected virtual Task CreateIndex(string indexName, IList<Field> providerFields)
@@ -375,8 +381,7 @@ namespace VirtoCommerce.AzureSearchModule.Data
             var providerFields = GetMappingFromCache(indexName);
             if (providerFields == null && await IndexExistsAsync(indexName))
             {
-                var index = await Client.Indexes.GetAsync(indexName);
-                providerFields = index.Fields;
+                providerFields = await GetIndexFields(indexName);
             }
 
             providerFields ??= new List<Field>();

--- a/src/VirtoCommerce.AzureSearchModule.Data/AzureSearchProvider.cs
+++ b/src/VirtoCommerce.AzureSearchModule.Data/AzureSearchProvider.cs
@@ -182,22 +182,9 @@ namespace VirtoCommerce.AzureSearchModule.Data
                     var isCollection = providerField.Type.ToString().StartsWith("Collection(");
 
                     var point = field.Value as GeoPoint;
-                    object value;
-                    if (point != null)
-                    {
-                        if (isCollection)
-                            value = field.Values.Select(v => ((GeoPoint)v).ToDocumentValue()).ToArray();
-                        else
-                            value = point.ToDocumentValue();
-                    }
-                    else
-                    {
-                        if (isCollection)
-                            value = field.Values;
-                        else
-                            value = field.Value;
-
-                    }
+                    var value = point != null
+                        ? (isCollection ? field.Values.Select(v => ((GeoPoint)v).ToDocumentValue()).ToArray() : point.ToDocumentValue())
+                        : (isCollection ? field.Values : field.Value);
 
                     result.Add(fieldName, value);
                 }

--- a/tests/VirtoCommerce.AzureSearchModule.Tests/AzureSearchTests.cs
+++ b/tests/VirtoCommerce.AzureSearchModule.Tests/AzureSearchTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.AzureSearchModule.Data;
 using VirtoCommerce.SearchModule.Core.Model;
@@ -11,16 +12,39 @@ namespace VirtoCommerce.AzureSearchModule.Tests
     [Trait("Category", "IntegrationTest")]
     public class AzureSearchTests : SearchProviderTests
     {
-        protected override ISearchProvider GetSearchProvider()
+        protected virtual IOptions<SearchOptions> GetSearchOptions()
+        {
+            return Options.Create(new SearchOptions { Scope = "test-core", Provider = "AzureSearch" });
+        }
+
+        protected virtual IOptions<AzureSearchOptions> GetAzureSearchOptions()
         {
             var searchServiceName = Environment.GetEnvironmentVariable("TestAzureSearchServiceName") ?? "Test SearchServiceName";
             var key = Environment.GetEnvironmentVariable("TestAzureSearchKey") ?? "Test key";
 
-            var azureSearchOptions = Options.Create(new AzureSearchOptions { SearchServiceName = searchServiceName, Key = key });
-            var options = Options.Create(new SearchOptions { Scope = "test-core", Provider = "AzureSearch" });
+            return Options.Create(new AzureSearchOptions { SearchServiceName = searchServiceName, Key = key });
+        }
+
+        protected override ISearchProvider GetSearchProvider()
+        {
+            var azureSearchOptions = GetAzureSearchOptions();
+            var options = GetSearchOptions();
 
             var provider = new AzureSearchProvider(azureSearchOptions, options, GetSettingsManager());
             return provider;
+        }
+
+        [Fact]
+        public virtual async Task CheckCallIsIndexExists()
+        {
+            var provider = new MockAzureSearchProvider(GetAzureSearchOptions(), GetSearchOptions(), GetSettingsManager());
+
+            Assert.Null(provider.CallGetMappingFromCache());
+
+            await provider.CallGetMappingAsync();
+
+            Assert.True(provider.IsIndexExistsAsyncCalled);
+            Assert.NotNull(provider.CallGetMappingFromCache());
         }
     }
 }

--- a/tests/VirtoCommerce.AzureSearchModule.Tests/MockAzureSearchProvider.cs
+++ b/tests/VirtoCommerce.AzureSearchModule.Tests/MockAzureSearchProvider.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Options;
+using VirtoCommerce.AzureSearchModule.Data;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.SearchModule.Core.Model;
+
+namespace VirtoCommerce.AzureSearchModule.Tests
+{
+    public class MockAzureSearchProvider : AzureSearchModule.Data.AzureSearchProvider
+    {
+        static string IndexName = "TestIndex";
+
+        public bool IsIndexExistsAsyncCalled { get; set; }
+
+        public MockAzureSearchProvider(IOptions<AzureSearchOptions> azureSearchOptions, IOptions<SearchOptions> searchOptions, ISettingsManager settingsManager) :
+            base(azureSearchOptions, searchOptions, settingsManager)
+        {
+            IsIndexExistsAsyncCalled = false;
+        }
+
+        protected override Task<IList<Field>> GetIndexFields(string indexName)
+        {
+            return Task.FromResult<IList<Field>>(new List<Field>());
+        }
+
+        protected override Task<bool> IndexExistsAsync(string indexName)
+        {
+            IsIndexExistsAsyncCalled = true;
+            return Task.FromResult(true);
+        }
+
+        public Task<IList<Field>> CallGetMappingAsync()
+        {
+            return GetMappingAsync(IndexName);
+        }
+
+        public IList<Field> CallGetMappingFromCache()
+        {
+            return GetMappingFromCache(IndexName);
+        }
+
+    }
+}


### PR DESCRIPTION
Provide a fix for Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. 