### PR TITLE
VCST-4697: Update Azure.Search.Documents to 11.8.0-beta.1

### DIFF
--- a/src/VirtoCommerce.AzureSearchModule.Data/VirtoCommerce.AzureSearchModule.Data.csproj
+++ b/src/VirtoCommerce.AzureSearchModule.Data/VirtoCommerce.AzureSearchModule.Data.csproj
@@ -12,7 +12,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Search.Documents" Version="11.6.0-beta.4" />
+    <PackageReference Include="Azure.Search.Documents" Version="11.8.0-beta.1" />
     <PackageReference Include="Microsoft.Spatial" Version="7.6.3" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.AzureSearchModule.Web/module.manifest
+++ b/src/VirtoCommerce.AzureSearchModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1001.0</version>
   <version-tag />
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1008.0-alpha.13209-vcst-4697-azurecore</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Search" version="3.1000.0" />
   </dependencies>

--- a/src/VirtoCommerce.AzureSearchModule.Web/module.manifest
+++ b/src/VirtoCommerce.AzureSearchModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1001.0</version>
   <version-tag />
 
-  <platformVersion>3.1008.0-alpha.13209-vcst-4697-azurecore</platformVersion>
+  <platformVersion>3.1010.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Search" version="3.1000.0" />
   </dependencies>


### PR DESCRIPTION
## Description
feat: Update Azure.Search.Documents to 11.8.0-beta.1

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4697
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureSearch_3.1001.0-pr-53-ac2e.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-touch change, but it upgrades the Azure Search SDK and increases the required platform version, which could introduce runtime/API compatibility issues in search integration.
> 
> **Overview**
> Updates the Azure Search module to use `Azure.Search.Documents` `11.8.0-beta.1` (from `11.6.0-beta.4`).
> 
> Bumps the module’s required `platformVersion` from `3.1002.0` to `3.1010.0` in `module.manifest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac2eeeda5e9337713a6184db6c7c1e17990cae08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->