### PR TITLE
VCST-5152: Refactor Azure Search module logging to structured templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,4 @@ __pycache__/
 
 # Webpack output
 dist/
+/.serena

--- a/README.md
+++ b/README.md
@@ -44,8 +44,32 @@ For example, if your query (`SearchRequest.SearchKeywords`) has three terms "uni
 * When `QueryParserType` is set to `Full`, [Lucene syntax rules](https://learn.microsoft.com/en-us/azure/search/query-lucene-syntax) are applied to the search string. 
   In order to use any of the search operators as part of the search text, [escape](https://learn.microsoft.com/en-us/azure/search/query-lucene-syntax#escaping-special-characters) the character by prefixing it with a single backslash (`\`).
 
+## Logging
+
+This module uses **structured logging**: every log entry is a stable, parameterized
+message template, with all variable runtime data (index, service, document type,
+HTTP status, request id, etc.) emitted as discrete named properties rather than
+concatenated into the message. Exceptions are always passed as the `Exception`
+argument so the logging pipeline can serialize them into structured fields.
+
+```csharp
+// ✅ stable template + structured properties (groupable, alertable)
+_logger.LogError(ex,
+    "Failed to index documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+    nameof(IndexWithRetryAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
+    exception.Status, exception.ErrorCode, GetAzureRequestId(exception));
+```
+
+This keeps every occurrence of the same logical event identical, so downstream sinks
+(e.g. New Relic) can group, filter, alert, and build dashboards on the discrete
+fields. New contributions to this module must follow the same pattern.
+
+See [Logging conventions](docs/logging-conventions.md) for the full rules, the
+property glossary, and before/after examples.
+
 ## Documentation
 
+* [Logging conventions](docs/logging-conventions.md)
 * [Azure Search module user documentation](https://docs.virtocommerce.org/platform/user-guide/azure-search/overview/)
 * [Azure Search module developer documentation](https://docs.virtocommerce.org/platform/developer-guide/Fundamentals/Indexed-Search/integration/configuring-azure-cognitive-search/)
 * [REST API](https://virtostart-demo-admin.govirto.com/docs/index.html?urls.primaryName=VirtoCommerce.AzureSearch)

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ argument so the logging pipeline can serialize them into structured fields.
 ```csharp
 // ✅ stable template + structured properties (groupable, alertable)
 _logger.LogError(ex,
-    "Failed to index documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+    "Failed to index documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}",
     nameof(IndexWithRetryAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
-    exception.Status, exception.ErrorCode, GetAzureRequestId(exception));
+    exception.Status, exception.ErrorCode);
 ```
 
 This keeps every occurrence of the same logical event identical, so downstream sinks

--- a/docs/logging-conventions.md
+++ b/docs/logging-conventions.md
@@ -50,10 +50,16 @@ and Serilog (message templates with named placeholders), so that downstream sink
 | `Operation`      | Logical operation / method name (`nameof(...)`)                |
 | `HttpStatus`     | HTTP status code from `RequestFailedException.Status`          |
 | `ErrorCode`      | Service error code from `RequestFailedException.ErrorCode`     |
-| `AzureRequestId` | Azure request id (`x-ms-request-id` response header)           |
 
 Validation events (e.g. field type mismatch) additionally use: `DocumentId`,
 `FieldName`, `DocumentFieldType`, `SchemaFieldType`.
+
+> **Note on the Azure request id.** Azure AI Search's `request-id` response header is the
+> *server operation trace id* intended for Microsoft Support tickets — it is **not** the
+> Portal "Request ID" and is not queryable in Azure Monitor diagnostic logs. For
+> self-service correlation, use Azure Monitor / Log Analytics (`AzureDiagnostics`,
+> `ResourceProvider == "MICROSOFT.SEARCH"`) and pivot on `OperationName` / `IndexName_s` /
+> time. We therefore do **not** emit it as a structured log property.
 
 ## Pattern: log-and-throw
 
@@ -65,9 +71,9 @@ original exception as the inner exception — no concatenated blob:
 catch (RequestFailedException ex)
 {
     _logger.LogError(ex,
-        "Failed to remove documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+        "Failed to remove documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}",
         nameof(RemoveAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
-        ex.Status, ex.ErrorCode, GetAzureRequestId(ex));
+        ex.Status, ex.ErrorCode);
 
     throw new SearchException("Failed to remove documents", ex);
 }
@@ -80,12 +86,11 @@ catch (RequestFailedException ex)
 StatusCode: 404; Content:The index 'sadevdefault-active-member' ... DocumentIds:... ; FieldNames:...
 
 // After — stable template + discrete fields
-message:        "Failed to index documents in IndexWithRetryAsync for member on index sadevdefault-active-member in service hei-selo-dev-ne-srch-1. HTTP 404, error code ..., request id 35e05517-..."
+message:        "Failed to index documents in IndexWithRetryAsync for member on index sadevdefault-active-member in service hei-selo-dev-ne-srch-1. HTTP 404, error code ..."
 Operation:      "IndexWithRetryAsync"
 DocumentType:   "member"
 SearchIndex:    "sadevdefault-active-member"
 SearchService:  "hei-selo-dev-ne-srch-1"
 HttpStatus:     404
-AzureRequestId: "35e05517-4cc1-4f20-bbd1-392266d0cbfc"
 exception:      <structured exception object, incl. inner exceptions and stack>
 ```

--- a/docs/logging-conventions.md
+++ b/docs/logging-conventions.md
@@ -1,0 +1,91 @@
+# Logging conventions
+
+These conventions apply to all logging in this module. They follow the standard
+structured-logging pattern supported natively by `Microsoft.Extensions.Logging`
+and Serilog (message templates with named placeholders), so that downstream sinks
+(e.g. New Relic) can group, filter, alert, and build dashboards on log events.
+
+## Rules
+
+1. **The message is a stable template, identical for every occurrence of the same
+   logical event.** Never build the message with string concatenation or `$"..."`
+   interpolation. Put variable data in named placeholders instead.
+
+   ```csharp
+   // ❌ Don't — unique string per call, not groupable
+   _logger.LogError(ex, $"Failed to index documents in {indexName} on {serviceName}");
+
+   // ✅ Do — stable template + structured properties
+   _logger.LogError(ex,
+       "Failed to index documents on index {SearchIndex} in service {SearchService}",
+       indexName, serviceName);
+   ```
+
+2. **Always pass the exception as the `Exception` argument** (first argument of
+   `LogError`), never concatenated into the message. The logging pipeline serializes
+   it into structured exception fields (including inner exceptions and stack trace).
+
+3. **Placeholder names are PascalCase** and drawn from the shared glossary below.
+   Placeholders bind to arguments **positionally**, so the placeholder order in the
+   template must match the argument order.
+
+4. **Keep cardinality low.** Do not put per-request high-cardinality values
+   (document ids, field-name lists, raw response bodies) into the structured error
+   event — they defeat grouping and inflate ingest cost. The underlying
+   `RequestFailedException` already carries the Azure response detail. If such values
+   are needed for debugging, emit them in a separate `LogDebug` line.
+
+5. **Templates must be constant expressions.** Analyzer `CA2254` (enforced as an
+   error via `TreatWarningsAsErrors`) forbids a variable/parameter template. The
+   literal template must live at the call site (or be a `const`); only value
+   extraction may be factored into a helper.
+
+## Glossary
+
+| Property         | Meaning                                                        |
+|------------------|----------------------------------------------------------------|
+| `SearchService`  | Azure Search service name (`AzureSearchOptions.SearchServiceName`) |
+| `SearchIndex`    | Target index or index alias name                               |
+| `DocumentType`   | Search document type (e.g. `member`, `product`)                |
+| `Operation`      | Logical operation / method name (`nameof(...)`)                |
+| `HttpStatus`     | HTTP status code from `RequestFailedException.Status`          |
+| `ErrorCode`      | Service error code from `RequestFailedException.ErrorCode`     |
+| `AzureRequestId` | Azure request id (`x-ms-request-id` response header)           |
+
+Validation events (e.g. field type mismatch) additionally use: `DocumentId`,
+`FieldName`, `DocumentFieldType`, `SchemaFieldType`.
+
+## Pattern: log-and-throw
+
+Catch sites that wrap an Azure error log the structured event (authoritative,
+Azure-specific) and then throw a `SearchException` with a **stable** message and the
+original exception as the inner exception — no concatenated blob:
+
+```csharp
+catch (RequestFailedException ex)
+{
+    _logger.LogError(ex,
+        "Failed to remove documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+        nameof(RemoveAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
+        ex.Status, ex.ErrorCode, GetAzureRequestId(ex));
+
+    throw new SearchException("Failed to remove documents", ex);
+}
+```
+
+### Before / after
+
+```text
+// Before — single multi-kilobyte, non-groupable message
+StatusCode: 404; Content:The index 'sadevdefault-active-member' ... DocumentIds:... ; FieldNames:...
+
+// After — stable template + discrete fields
+message:        "Failed to index documents in IndexWithRetryAsync for member on index sadevdefault-active-member in service hei-selo-dev-ne-srch-1. HTTP 404, error code ..., request id 35e05517-..."
+Operation:      "IndexWithRetryAsync"
+DocumentType:   "member"
+SearchIndex:    "sadevdefault-active-member"
+SearchService:  "hei-selo-dev-ne-srch-1"
+HttpStatus:     404
+AzureRequestId: "35e05517-4cc1-4f20-bbd1-392266d0cbfc"
+exception:      <structured exception object, incl. inner exceptions and stack>
+```

--- a/src/VirtoCommerce.AzureSearchModule.Data/AzureSearchDocumentsProvider.cs
+++ b/src/VirtoCommerce.AzureSearchModule.Data/AzureSearchDocumentsProvider.cs
@@ -94,9 +94,9 @@ namespace VirtoCommerce.AzureSearchModule.Data
             catch (RequestFailedException ex)
             {
                 _logger.LogError(ex,
-                    "Failed to delete index in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                    "Failed to delete index in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}",
                     nameof(DeleteIndexAsync), documentType, indexAlias, _azureSearchOptions.SearchServiceName,
-                    ex.Status, ex.ErrorCode, GetAzureRequestId(ex));
+                    ex.Status, ex.ErrorCode);
 
                 throw new SearchException("Failed to delete index", ex);
             }
@@ -137,9 +137,9 @@ namespace VirtoCommerce.AzureSearchModule.Data
             catch (RequestFailedException ex)
             {
                 _logger.LogError(ex,
-                    "Failed to remove documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                    "Failed to remove documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}",
                     nameof(RemoveAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
-                    ex.Status, ex.ErrorCode, GetAzureRequestId(ex));
+                    ex.Status, ex.ErrorCode);
 
                 throw new SearchException("Failed to remove documents", ex);
             }
@@ -180,9 +180,9 @@ namespace VirtoCommerce.AzureSearchModule.Data
             catch (RequestFailedException ex)
             {
                 _logger.LogError(ex,
-                    "Failed to execute search in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                    "Failed to execute search in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}",
                     nameof(SearchAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
-                    ex.Status, ex.ErrorCode, GetAzureRequestId(ex));
+                    ex.Status, ex.ErrorCode);
 
                 throw new SearchException("Failed to execute search", ex);
             }
@@ -225,9 +225,9 @@ namespace VirtoCommerce.AzureSearchModule.Data
             catch (RequestFailedException ex)
             {
                 _logger.LogError(ex,
-                    "Failed to get suggestions in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                    "Failed to get suggestions in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}",
                     nameof(GetSuggestionsAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
-                    ex.Status, ex.ErrorCode, GetAzureRequestId(ex));
+                    ex.Status, ex.ErrorCode);
 
                 throw new SearchException("Failed to get suggestions", ex);
             }
@@ -348,9 +348,9 @@ namespace VirtoCommerce.AzureSearchModule.Data
             catch (RequestFailedException exception)
             {
                 _logger.LogError(exception,
-                    "Failed to index documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                    "Failed to index documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}",
                     nameof(IndexWithRetryAsync), documentType, createIndexResult.IndexName, _azureSearchOptions.SearchServiceName,
-                    exception.Status, exception.ErrorCode, GetAzureRequestId(exception));
+                    exception.Status, exception.ErrorCode);
 
                 throw new SearchException("Failed to index documents", exception);
             }
@@ -382,9 +382,9 @@ namespace VirtoCommerce.AzureSearchModule.Data
                 catch (RequestFailedException exception)
                 {
                     _logger.LogError(exception,
-                        "Failed to create index in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                        "Failed to create index in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}",
                         nameof(InternalCreateIndexAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
-                        exception.Status, exception.ErrorCode, GetAzureRequestId(exception));
+                        exception.Status, exception.ErrorCode);
 
                     throw new SearchException("Failed to create index", exception);
                 }
@@ -399,9 +399,9 @@ namespace VirtoCommerce.AzureSearchModule.Data
                 catch (RequestFailedException exception)
                 {
                     _logger.LogError(exception,
-                        "Failed to update index mapping in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                        "Failed to update index mapping in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}",
                         nameof(UpdateMapping), documentType, indexName, _azureSearchOptions.SearchServiceName,
-                        exception.Status, exception.ErrorCode, GetAzureRequestId(exception));
+                        exception.Status, exception.ErrorCode);
 
                     throw new SearchException("Failed to update index mapping", exception);
                 }
@@ -805,13 +805,6 @@ namespace VirtoCommerce.AzureSearchModule.Data
         }
 
         #endregion
-
-        private static string GetAzureRequestId(RequestFailedException exception)
-        {
-            return exception.GetRawResponse()?.Headers.TryGetValue("x-ms-request-id", out var requestId) == true
-                ? requestId
-                : null;
-        }
 
         protected virtual SearchClient GetSearchIndexClient(string indexName)
         {

--- a/src/VirtoCommerce.AzureSearchModule.Data/AzureSearchDocumentsProvider.cs
+++ b/src/VirtoCommerce.AzureSearchModule.Data/AzureSearchDocumentsProvider.cs
@@ -75,9 +75,11 @@ namespace VirtoCommerce.AzureSearchModule.Data
         {
             ArgumentNullException.ThrowIfNull(documentType);
 
+            string indexAlias = null;
+
             try
             {
-                var indexAlias = GetIndexAlias(BackupIndexAlias, documentType);
+                indexAlias = GetIndexAlias(BackupIndexAlias, documentType);
 
                 if (await IndexExistsAsync(indexAlias))
                 {
@@ -91,7 +93,12 @@ namespace VirtoCommerce.AzureSearchModule.Data
             }
             catch (RequestFailedException ex)
             {
-                ThrowException("Failed to delete index", ex);
+                _logger.LogError(ex,
+                    "Failed to delete index in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                    nameof(DeleteIndexAsync), documentType, indexAlias, _azureSearchOptions.SearchServiceName,
+                    ex.Status, ex.ErrorCode, GetAzureRequestId(ex));
+
+                throw new SearchException("Failed to delete index", ex);
             }
         }
 
@@ -112,10 +119,11 @@ namespace VirtoCommerce.AzureSearchModule.Data
         public virtual async Task<IndexingResult> RemoveAsync(string documentType, IList<IndexDocument> documents)
         {
             IndexingResult result;
+            string indexName = null;
 
             try
             {
-                var indexName = GetIndexName(ActiveIndexAlias, documentType);
+                indexName = GetIndexName(ActiveIndexAlias, documentType);
 
                 var providerDocuments = documents.Select(document => ConvertToProviderDocument(document, null, documentType)).ToList();
 
@@ -128,7 +136,12 @@ namespace VirtoCommerce.AzureSearchModule.Data
             }
             catch (RequestFailedException ex)
             {
-                throw new SearchException(ex.Message, ex);
+                _logger.LogError(ex,
+                    "Failed to remove documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                    nameof(RemoveAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
+                    ex.Status, ex.ErrorCode, GetAzureRequestId(ex));
+
+                throw new SearchException("Failed to remove documents", ex);
             }
 
             return result;
@@ -164,9 +177,22 @@ namespace VirtoCommerce.AzureSearchModule.Data
 
                 return result;
             }
+            catch (RequestFailedException ex)
+            {
+                _logger.LogError(ex,
+                    "Failed to execute search in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                    nameof(SearchAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
+                    ex.Status, ex.ErrorCode, GetAzureRequestId(ex));
+
+                throw new SearchException("Failed to execute search", ex);
+            }
             catch (Exception ex)
             {
-                throw new SearchException(ex.Message, ex);
+                _logger.LogError(ex,
+                    "Failed to execute search in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}",
+                    nameof(SearchAsync), documentType, indexName, _azureSearchOptions.SearchServiceName);
+
+                throw new SearchException("Failed to execute search", ex);
             }
         }
 
@@ -179,9 +205,11 @@ namespace VirtoCommerce.AzureSearchModule.Data
                 return result;
             }
 
+            string indexName = null;
+
             try
             {
-                var indexName = GetIndexName(documentType);
+                indexName = GetIndexName(documentType);
 
                 var indexClient = GetSearchIndexClient(indexName);
 
@@ -196,7 +224,12 @@ namespace VirtoCommerce.AzureSearchModule.Data
             }
             catch (RequestFailedException ex)
             {
-                throw new SearchException(ex.Message, ex);
+                _logger.LogError(ex,
+                    "Failed to get suggestions in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                    nameof(GetSuggestionsAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
+                    ex.Status, ex.ErrorCode, GetAzureRequestId(ex));
+
+                throw new SearchException("Failed to get suggestions", ex);
             }
 
             return result;
@@ -226,7 +259,7 @@ namespace VirtoCommerce.AzureSearchModule.Data
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Error while putting an active alias on a default index at {nameof(AddActiveAlias)}. Possible fail on Elastic server side at IndexExists check.");
+                _logger.LogError(ex, "Failed to add active alias on default index in {Operation}", nameof(AddActiveAlias));
             }
         }
 
@@ -305,7 +338,7 @@ namespace VirtoCommerce.AzureSearchModule.Data
         {
             var createIndexResult = await InternalCreateIndexAsync(documentType, documents, parameters);
 
-            var result = await IndexWithRetryAsync(createIndexResult.IndexName, createIndexResult.ProviderDocuments, 10, parameters.PartialUpdate);
+            var result = await IndexWithRetryAsync(createIndexResult.IndexName, documentType, createIndexResult.ProviderDocuments, 10, parameters.PartialUpdate);
             return result;
         }
 
@@ -334,13 +367,18 @@ namespace VirtoCommerce.AzureSearchModule.Data
                 }
                 catch (RequestFailedException exception)
                 {
-                    ThrowException(exception, providerFields: providerFields);
+                    _logger.LogError(exception,
+                        "Failed to create index in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                        nameof(InternalCreateIndexAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
+                        exception.Status, exception.ErrorCode, GetAzureRequestId(exception));
+
+                    throw new SearchException("Failed to create index", exception);
                 }
             }
 
             if (updateMapping)
             {
-                await UpdateMapping(indexName, providerFields);
+                await UpdateMapping(indexName, documentType, providerFields);
             }
 
             return new CreateIndexResult
@@ -392,8 +430,11 @@ namespace VirtoCommerce.AzureSearchModule.Data
 
                     if (!FieldTypeMatch(providerFieldType, providerField.Type))
                     {
-                        var message = $"Field type mismatch. Document type: {documentType}. Document Id: {document.Id}. Field name: {field.Name}. Document field type: {providerFieldType}. Schema field type: {providerField.Type}";
-                        ThrowException(message, null);
+                        _logger.LogError(
+                            "Field type mismatch for {DocumentType} document {DocumentId}, field {FieldName}: document field type {DocumentFieldType} does not match schema field type {SchemaFieldType}",
+                            documentType, document.Id, field.Name, providerFieldType, providerField.Type);
+
+                        throw new SearchException("Field type mismatch", null);
                     }
 
                     var value = GetFieldValue(field, isGeoPoint, isComplex, isCollection);
@@ -518,7 +559,7 @@ namespace VirtoCommerce.AzureSearchModule.Data
             }
         }
 
-        protected virtual async Task<IndexingResult> IndexWithRetryAsync(string indexName, IList<SearchDocument> providerDocuments, int retryCount, bool partialUpdate)
+        protected virtual async Task<IndexingResult> IndexWithRetryAsync(string indexName, string documentType, IList<SearchDocument> providerDocuments, int retryCount, bool partialUpdate)
         {
             if (providerDocuments.Count == 0)
             {
@@ -548,7 +589,12 @@ namespace VirtoCommerce.AzureSearchModule.Data
                 }
                 catch (RequestFailedException exception)
                 {
-                    ThrowException(exception, providerDocuments: providerDocuments);
+                    _logger.LogError(exception,
+                        "Failed to index documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                        nameof(IndexWithRetryAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
+                        exception.Status, exception.ErrorCode, GetAzureRequestId(exception));
+
+                    throw new SearchException("Failed to index documents", exception);
                 }
             }
 
@@ -714,7 +760,7 @@ namespace VirtoCommerce.AzureSearchModule.Data
             return providerFields;
         }
 
-        protected virtual async Task UpdateMapping(string indexName, IList<SearchField> providerFields)
+        protected virtual async Task UpdateMapping(string indexName, string documentType, IList<SearchField> providerFields)
         {
             var index = CreateIndexDefinition(indexName, providerFields);
 
@@ -726,7 +772,12 @@ namespace VirtoCommerce.AzureSearchModule.Data
             }
             catch (RequestFailedException exception)
             {
-                ThrowException(exception, providerFields: providerFields);
+                _logger.LogError(exception,
+                    "Failed to update index mapping in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                    nameof(UpdateMapping), documentType, indexName, _azureSearchOptions.SearchServiceName,
+                    exception.Status, exception.ErrorCode, GetAzureRequestId(exception));
+
+                throw new SearchException("Failed to update index mapping", exception);
             }
         }
 
@@ -747,28 +798,11 @@ namespace VirtoCommerce.AzureSearchModule.Data
 
         #endregion
 
-        private void ThrowException(string message, Exception innerException)
+        private static string GetAzureRequestId(RequestFailedException exception)
         {
-            throw new SearchException($"{message}. Search service name: {_azureSearchOptions.SearchServiceName}, Scope: {_searchOptions.Scope}", innerException);
-        }
-
-        private static void ThrowException(RequestFailedException exception, IList<SearchField> providerFields = null, IEnumerable<SearchDocument> providerDocuments = null)
-        {
-            var error = $"StatusCode: {exception.Status}; Content:{exception.Message}";
-
-            if (providerDocuments != null)
-            {
-                var documentIds = string.Join(',', providerDocuments.Select(x => x.GetString(AzureSearchHelper.ToAzureFieldName("id"))));
-                error = $"{error}; DocumentIds:{documentIds}";
-            }
-
-            if (providerFields != null)
-            {
-                var fieldNames = string.Join(',', providerFields.Select(x => x.Name));
-                error = $"{error}; FieldNames:{fieldNames}";
-            }
-
-            throw new SearchException(error, exception);
+            return exception.GetRawResponse()?.Headers.TryGetValue("x-ms-request-id", out var requestId) == true
+                ? requestId
+                : null;
         }
 
         protected virtual SearchClient GetSearchIndexClient(string indexName)

--- a/src/VirtoCommerce.AzureSearchModule.Data/AzureSearchDocumentsProvider.cs
+++ b/src/VirtoCommerce.AzureSearchModule.Data/AzureSearchDocumentsProvider.cs
@@ -259,7 +259,9 @@ namespace VirtoCommerce.AzureSearchModule.Data
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to add active alias on default index in {Operation}", nameof(AddActiveAlias));
+                _logger.LogError(ex,
+                    "Failed to add active alias on default index in {Operation} in service {SearchService}",
+                    nameof(AddActiveAlias), _azureSearchOptions.SearchServiceName);
             }
         }
 
@@ -338,8 +340,20 @@ namespace VirtoCommerce.AzureSearchModule.Data
         {
             var createIndexResult = await InternalCreateIndexAsync(documentType, documents, parameters);
 
-            var result = await IndexWithRetryAsync(createIndexResult.IndexName, documentType, createIndexResult.ProviderDocuments, 10, parameters.PartialUpdate);
-            return result;
+            try
+            {
+                var result = await IndexWithRetryAsync(createIndexResult.IndexName, createIndexResult.ProviderDocuments, 10, parameters.PartialUpdate);
+                return result;
+            }
+            catch (RequestFailedException exception)
+            {
+                _logger.LogError(exception,
+                    "Failed to index documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                    nameof(IndexWithRetryAsync), documentType, createIndexResult.IndexName, _azureSearchOptions.SearchServiceName,
+                    exception.Status, exception.ErrorCode, GetAzureRequestId(exception));
+
+                throw new SearchException("Failed to index documents", exception);
+            }
         }
 
         protected virtual async Task<CreateIndexResult> InternalCreateIndexAsync(string documentType, IList<IndexDocument> documents, IndexingParameters parameters)
@@ -378,7 +392,19 @@ namespace VirtoCommerce.AzureSearchModule.Data
 
             if (updateMapping)
             {
-                await UpdateMapping(indexName, documentType, providerFields);
+                try
+                {
+                    await UpdateMapping(indexName, providerFields);
+                }
+                catch (RequestFailedException exception)
+                {
+                    _logger.LogError(exception,
+                        "Failed to update index mapping in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
+                        nameof(UpdateMapping), documentType, indexName, _azureSearchOptions.SearchServiceName,
+                        exception.Status, exception.ErrorCode, GetAzureRequestId(exception));
+
+                    throw new SearchException("Failed to update index mapping", exception);
+                }
             }
 
             return new CreateIndexResult
@@ -559,7 +585,7 @@ namespace VirtoCommerce.AzureSearchModule.Data
             }
         }
 
-        protected virtual async Task<IndexingResult> IndexWithRetryAsync(string indexName, string documentType, IList<SearchDocument> providerDocuments, int retryCount, bool partialUpdate)
+        protected virtual async Task<IndexingResult> IndexWithRetryAsync(string indexName, IList<SearchDocument> providerDocuments, int retryCount, bool partialUpdate)
         {
             if (providerDocuments.Count == 0)
             {
@@ -587,15 +613,8 @@ namespace VirtoCommerce.AzureSearchModule.Data
                     // Need to wait some time until new mapping is applied
                     await Task.Delay(MillisecondsDelay);
                 }
-                catch (RequestFailedException exception)
-                {
-                    _logger.LogError(exception,
-                        "Failed to index documents in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
-                        nameof(IndexWithRetryAsync), documentType, indexName, _azureSearchOptions.SearchServiceName,
-                        exception.Status, exception.ErrorCode, GetAzureRequestId(exception));
-
-                    throw new SearchException("Failed to index documents", exception);
-                }
+                // Any other RequestFailedException propagates to the caller (InternalIndexAsync),
+                // which logs it with full document-type context and wraps it in a SearchException.
             }
 
             return result;
@@ -760,25 +779,14 @@ namespace VirtoCommerce.AzureSearchModule.Data
             return providerFields;
         }
 
-        protected virtual async Task UpdateMapping(string indexName, string documentType, IList<SearchField> providerFields)
+        protected virtual async Task UpdateMapping(string indexName, IList<SearchField> providerFields)
         {
             var index = CreateIndexDefinition(indexName, providerFields);
 
-            try
-            {
-
-                var updatedIndex = await Client.CreateOrUpdateIndexAsync(index);
-                AddMappingToCache(indexName, updatedIndex.Value.Fields);
-            }
-            catch (RequestFailedException exception)
-            {
-                _logger.LogError(exception,
-                    "Failed to update index mapping in {Operation} for {DocumentType} on index {SearchIndex} in service {SearchService}. HTTP {HttpStatus}, error code {ErrorCode}, request id {AzureRequestId}",
-                    nameof(UpdateMapping), documentType, indexName, _azureSearchOptions.SearchServiceName,
-                    exception.Status, exception.ErrorCode, GetAzureRequestId(exception));
-
-                throw new SearchException("Failed to update index mapping", exception);
-            }
+            // RequestFailedException propagates to the caller (InternalCreateIndexAsync),
+            // which logs it with full document-type context and wraps it in a SearchException.
+            var updatedIndex = await Client.CreateOrUpdateIndexAsync(index);
+            AddMappingToCache(indexName, updatedIndex.Value.Fields);
         }
 
         protected virtual IList<SearchField> GetMappingFromCache(string indexName)

--- a/tests/VirtoCommerce.AzureSearchModule.Tests/MockAzureSearchProvider.cs
+++ b/tests/VirtoCommerce.AzureSearchModule.Tests/MockAzureSearchProvider.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Search.Documents.Indexes.Models;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.AzureSearchModule.Data;
 using VirtoCommerce.Platform.Core.Settings;
@@ -20,7 +21,7 @@ namespace VirtoCommerce.AzureSearchModule.Tests
             ISettingsManager settingsManager,
             IAzureSearchDocumentsRequestBuilder requestBuilder,
             IAzureSearchDocumentsResponseBuilder responseBuilder) :
-            base(azureSearchOptions, searchOptions, settingsManager, requestBuilder, responseBuilder, null)
+            base(azureSearchOptions, searchOptions, settingsManager, requestBuilder, responseBuilder, NullLogger<AzureSearchDocumentsProvider>.Instance)
         {
             IsIndexExistsAsyncCalled = false;
         }


### PR DESCRIPTION
## Description
feat: Refactor Azure Search module logging to structured templates

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5152
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureSearch_3.1002.0-pr-54-393f.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how search/index failures are logged and surfaced (message text and grouping), which may affect existing alerts or support workflows, though core throw/retry behavior is largely preserved.
> 
> **Overview**
> Replaces ad-hoc **`ThrowException`** helpers and interpolated log messages in **`AzureSearchDocumentsProvider`** with **structured `LogError` templates** (e.g. `{Operation}`, `{DocumentType}`, `{SearchIndex}`, `{SearchService}`, `{HttpStatus}`, `{ErrorCode}`) and **stable `SearchException` messages** with the original exception as inner—removing high-cardinality blobs (document ids, field lists) from thrown/logged text.
> 
> **Error handling** is centralized at operation boundaries: indexing retries still delay on mapping/404, but other Azure failures bubble to callers that log once; **search** and **suggestions** gain explicit **`RequestFailedException`** logging; **field type mismatch** logs structured validation fields.
> 
> Adds **`docs/logging-conventions.md`** and a **README** logging section; test mock passes **`NullLogger`**; minor **`.gitignore`** tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 393f507defd5e6194629b89194987bf5a08615ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->